### PR TITLE
Added memory corruption check

### DIFF
--- a/lib/tester.c
+++ b/lib/tester.c
@@ -211,8 +211,14 @@ static int test_instruction(struct test_inst *inst)
         }
 
         state.num_mem_accesses = 0;
-
+        u8 imem_old[INSTRUCTION_MEM_SIZE] = {0};
+        memcpy(instruction_mem, imem_old, INSTRUCTION_MEM_SIZE);
         last_op_had_failure = run_state(&state);
+        //if instruction mem was modified
+        if (memcmp(imem_old, instruction_mem, INSTRUCTION_MEM_SIZE)) {
+            printf("Ouch, your testcpu should NOT write to instruction_mem\n");
+            exit(1);
+        }
 
         last_op = opcode;
         op_success_table[opcode] = !last_op_had_failure;


### PR DESCRIPTION
Hi,

this patches checks if the testcpu modifies the instruction_mem. That way users of the testframework see that their testcpu should log the mem writes instead of actually writing to it.