### PR TITLE
Fix instruction_men always zero, only run NOPs

### DIFF
--- a/lib/tester.c
+++ b/lib/tester.c
@@ -212,7 +212,7 @@ static int test_instruction(struct test_inst *inst)
 
         state.num_mem_accesses = 0;
         u8 imem_old[INSTRUCTION_MEM_SIZE] = {0};
-        memcpy(instruction_mem, imem_old, INSTRUCTION_MEM_SIZE);
+        memcpy(imem_old, instruction_mem, INSTRUCTION_MEM_SIZE);
         last_op_had_failure = run_state(&state);
         //if instruction mem was modified
         if (memcmp(imem_old, instruction_mem, INSTRUCTION_MEM_SIZE)) {


### PR DESCRIPTION
I runs "gbit -k" with my  GBCPU emulator only support NOP and set/get_states, passed the test.

Finally I found the "- Instruction -" is always NOPs.

And the root cause is that the instruction memory value is always zero because it is writed to zero befure all tests.

Please kindly see lib/tester.c line 215 and read C/C++ manual to confirm my pull request.
https://cplusplus.com/reference/cstring/memcpy/
void * memcpy ( void * destination, const void * source, size_t num );

Thanks.